### PR TITLE
Concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+﻿# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Plugins
+*.aax
+*.vst
+*.vst3
+
+# Build
+**/build
+
+# Artifacts
+*.zip

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -270,7 +270,7 @@ void ProteusAudioProcessor::setStateInformation (const void* data, int sizeInByt
 }
 
 
-void ProteusAudioProcessor::loadConfig(File configFile)
+void ProteusAudioProcessor::loadConfig(const File& configFile)
 {
     this->suspendProcessing(true);
     pauseVolume = 3;

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -23,8 +23,8 @@ ProteusAudioProcessor::ProteusAudioProcessor()
 #endif
     ),
 
-    treeState(*this, nullptr, "PARAMETER", { std::make_unique<AudioParameterFloat>(GAIN_ID, GAIN_NAME, NormalisableRange<float>(0.0f, 1.0f, 0.01f), 0.5f),
-                        std::make_unique<AudioParameterFloat>(MASTER_ID, MASTER_NAME, NormalisableRange<float>(0.0f, 1.0f, 0.01f), 0.5) })
+    treeState(*this, nullptr, "PARAMETER", { std::make_unique<AudioParameterFloat>(GAIN_ID, GAIN_NAME, NormalisableRange(0.0f, 1.0f, 0.01f), 0.5f),
+                        std::make_unique<AudioParameterFloat>(MASTER_ID, MASTER_NAME, NormalisableRange(0.0f, 1.0f, 0.01f), 0.5) })
 
     
 #endif
@@ -116,7 +116,7 @@ void ProteusAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBloc
 
 
     dsp::ProcessSpec specMono { sampleRate, static_cast<uint32> (samplesPerBlock), 1 };
-    dsp::ProcessSpec spec{ sampleRate, static_cast<uint32> (samplesPerBlock), 2 };
+    const dsp::ProcessSpec spec{ sampleRate, static_cast<uint32> (samplesPerBlock), 2 };
 
     dcBlocker.prepare (spec); 
 
@@ -160,11 +160,11 @@ void ProteusAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer
 {
     ScopedNoDenormals noDenormals;
 
-    auto driveValue = driveParam->load();
-    auto masterValue = masterParam->load();
+    const float driveValue = driveParam->load();
+    const float masterValue = masterParam->load();
 
     dsp::AudioBlock<float> block(buffer);
-    dsp::ProcessContextReplacing context(block);
+    const dsp::ProcessContextReplacing context(block);
 
     // Overdrive Pedal ================================================================== 
     if (fw_state == 1 && model_loaded == true) {
@@ -228,9 +228,9 @@ void ProteusAudioProcessor::getStateInformation (MemoryBlock& destData)
     // You should use this method to store your parameters in the memory block.
     // You could do that either as raw data, or use the XML or ValueTree classes
     // as intermediaries to make it easy to save and load complex data.
-    
-    auto state = treeState.copyState();
-    std::unique_ptr<XmlElement> xml (state.createXml());
+
+    const auto state = treeState.copyState();
+    const std::unique_ptr xml (state.createXml());
     xml->setAttribute ("fw_state", fw_state);
     xml->setAttribute("folder", folder.getFullPathName().toStdString());
     xml->setAttribute("saved_model", saved_model.getFullPathName().toStdString());
@@ -244,19 +244,19 @@ void ProteusAudioProcessor::setStateInformation (const void* data, int sizeInByt
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
 
-    std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
+    const std::unique_ptr xmlState (getXmlFromBinary (data, sizeInBytes));
 
-    if (xmlState.get() != nullptr)
+    if (xmlState != nullptr)
     {
         if (xmlState->hasTagName (treeState.state.getType()))
         {
-            treeState.replaceState (juce::ValueTree::fromXml (*xmlState));
+            treeState.replaceState (ValueTree::fromXml (*xmlState));
             fw_state = xmlState->getBoolAttribute ("fw_state");
-            File temp_saved_model = xmlState->getStringAttribute("saved_model");
+            const File temp_saved_model = xmlState->getStringAttribute("saved_model");
             saved_model = temp_saved_model;
 
             current_model_index = xmlState->getIntAttribute("current_model_index");
-            File temp = xmlState->getStringAttribute("folder");
+            const File temp = xmlState->getStringAttribute("folder");
             folder = temp;
             if (auto* editor = dynamic_cast<ProteusAudioProcessorEditor*> (getActiveEditor()))
                 editor->resetImages();
@@ -274,7 +274,7 @@ void ProteusAudioProcessor::loadConfig(File configFile)
 {
     this->suspendProcessing(true);
     pauseVolume = 3;
-    String path = configFile.getFullPathName();
+    const String& path = configFile.getFullPathName();
     char_filename = path.toUTF8();
 
     LSTM.reset();
@@ -296,7 +296,7 @@ void ProteusAudioProcessor::loadConfig(File configFile)
 
 void ProteusAudioProcessor::LSTMProcess(const AudioBuffer<float>& buffer, dsp::AudioBlock<float> block, float driveValue)
 {
-    auto block44k = resampler.processIn(block);
+    const auto block44k = resampler.processIn(block);
     
     if (buffer.getNumChannels() == 2)
     {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -320,7 +320,7 @@ void ProteusAudioProcessor::LSTMProcess(const AudioBuffer<float>& buffer, dsp::A
     else
     {
         const auto channel = block44k.getChannelPointer(0);
-        LSTM2.process(channel, driveValue, channel, static_cast<int>(block44k.getNumSamples()));
+        LSTM.process(channel, driveValue, channel, static_cast<int>(block44k.getNumSamples()));
     }
 }
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -19,6 +19,7 @@
 #define MASTER_NAME "Level"
 
 #include <nlohmann/json.hpp>
+#include <ppl.h>
 #include "RTNeuralLSTM.h"
 
 //==============================================================================
@@ -91,6 +92,8 @@ public:
 
 private:
 
+	void LSTMProcess(const AudioBuffer<float>& buffer, dsp::AudioBlock<float> block44k, float driveValue);
+	
     std::atomic<float>* driveParam = nullptr;
     std::atomic<float>* masterParam = nullptr;
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -92,7 +92,7 @@ public:
 
 private:
 
-	void LSTMProcess(const AudioBuffer<float>& buffer, dsp::AudioBlock<float> block44k, float driveValue);
+	void LSTMProcess(const AudioBuffer<float>& buffer, dsp::AudioBlock<float> block, float driveValue);
 	
     std::atomic<float>* driveParam = nullptr;
     std::atomic<float>* masterParam = nullptr;

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -66,7 +66,7 @@ public:
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     // Files and configuration
-    void loadConfig(File configFile);
+    void loadConfig(const File& configFile);
 
     // Pedal/amp states
     int fw_state = 1;       // 0 = off, 1 = on


### PR DESCRIPTION
Allows stereo to be processed in parallel, will run without concurrency if in mono. Reduces processing time per sample buffer.
Added annotations to the changes. Best viewed in the [changes](https://github.com/GuitarML/Proteus/pull/4/files) tab.