### PR TITLE
Separate artifacts in CI, multiple tweaks for Linux, CLAP support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,19 +7,20 @@ jobs:
     name: Test plugin on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest] 
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     
     steps:
     - name: install linux deps
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update
-        sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev lv2-dev
+        sudo apt update
+        sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev \
+          libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev lv2-dev
     - uses: lukka/get-cmake@latest
 
-    - uses: actions/checkout@latest
+    - uses: actions/checkout@v3
       with: { submodules: recursive }
 
     - name: Configure
@@ -34,70 +35,70 @@ jobs:
     #  if: runner.os == 'Windows'
     #  run: bash validate.sh
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-lv2
         path: Proteus/Proteus/build/Proteus_artefacts/LV2/*.lv2
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-vst3.so
         path: Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-clap.clap
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-standalone
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Windows'
       with:
         name: proteus-windows-x64-shared.lib
         path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus_SharedCode.lib
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'Windows'
       with:
         name: proteus-windows-x64-vst3.dll
         path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus.dll
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-au
         path: Proteus/Proteus/build/Proteus_artefacts/AU/Proteus.component/Contents/MacOS/Proteus
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-vst3
         path: Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-clap.clap
         path: Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@latest
+    - uses: actions/upload-artifact@v3
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-standalone

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,25 +10,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    
-    steps:
-    - name: install linux deps
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt update
-        sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev \
-          libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev lv2-dev
-    - uses: lukka/get-cmake@latest
 
+    steps:
     - uses: actions/checkout@v3
       with: { submodules: recursive }
 
-    - name: Configure
-      shell: bash
-      run: cmake -Bbuild
+    - name: install linux deps
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      if: runner.os == 'Linux'
+      with:
+        packages:
+          libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev
+          libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev
+          libjack-jackd2-dev lv2-dev
+        version: 1.0
 
-    - name: Build
-      run: cmake --build build --config Release
+    - uses: lukka/get-cmake@latest
+    - run: cmake -Bbuild
+    - run: cmake --build build --config Release
     
     # Failing validation, fix
     #- name: Validate

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,10 +20,10 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
     - name: Get latest CMake
-      uses: lukka/get-cmake
+      uses: lukka/get-cmake@latest
 
     - name: Checkout code
-      uses: actions/checkout
+      uses: actions/checkout@latest
       with:
         submodules: recursive
 
@@ -40,40 +40,39 @@ jobs:
     #  if: runner.os == 'Windows'
     #  run: bash validate.sh
 
-    - uses: actions/upload-artifact
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-lv2
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/LV2/Proteus.lv2
-    - uses: actions/upload-artifact
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-vst3.so
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
-    - uses: actions/upload-artifact
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-standalone
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
 
     # couldn't find .vst3
-    - uses: actions/upload-artifact
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'Windows'
       with:
         name: proteus-windows-x64-shared.lib
         path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus_SharedCode.lib
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-au
         path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/AU/Proteus.component/Contents/MacOS/Proteus
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-vst3
         path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-standalone

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest] 
+        os: [ubuntu-latest, windows-latest, macOS-latest] 
     
     steps:
     - name: Install Linux Deps
@@ -34,7 +34,7 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout
       with:
         submodules: recursive
 
@@ -51,23 +51,41 @@ jobs:
     #  if: runner.os == 'Windows'
     #  run: bash validate.sh
 
-    - name: Upload Linux Artifact GitHub Action
+    - uses: actions/upload-artifact
       if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v2
-      with: 
-        name: linux-assets
-        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts
-        
-    - name: Upload Mac Artifact GitHub Action
-      if: runner.os == 'macOS'
-      uses: actions/upload-artifact@v2
       with:
-        name: mac-assets
-        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts
-        
-    - name: Upload Windows Artifact GitHub Action
+        name: proteus-linux-x64-lv2
+        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/LV2/Proteus.lv2
+    - uses: actions/upload-artifact
+      if: runner.os == 'Linux'
+      with:
+        name: proteus-linux-x64-vst3.so
+        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
+    - uses: actions/upload-artifact
+      if: runner.os == 'Linux'
+      with:
+        name: proteus-linux-x64-standalone
+        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
+
+    # couldn't find .vst3
+    - uses: actions/upload-artifact
       if: runner.os == 'Windows'
-      uses: actions/upload-artifact@v2
       with:
-        name: win-assets
-        path: D:/a/Proteus/Proteus/build/Proteus_artefacts
+        name: proteus-windows-x64-shared.lib
+        path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus_SharedCode.lib
+
+    - uses: actions/upload-artifact@v2
+      if: runner.os == 'macOS'
+      with:
+        name: proteus-mac-x64-au
+        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/AU/Proteus.component/Contents/MacOS/Proteus
+    - uses: actions/upload-artifact@v2
+      if: runner.os == 'macOS'
+      with:
+        name: proteus-mac-x64-vst3
+        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
+    - uses: actions/upload-artifact@v2
+      if: runner.os == 'macOS'
+      with:
+        name: proteus-mac-x64-standalone
+        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus.app/Contents/MacOS/Proteus

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,78 +12,94 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest] 
     
     steps:
-    - name: Install Linux Deps
+    - name: install linux deps
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev lv2-dev
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-    - name: Get latest CMake
-      uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@latest
 
-    - name: Checkout code
-      uses: actions/checkout@latest
-      with:
-        submodules: recursive
+    - uses: actions/checkout@latest
+      with: { submodules: recursive }
 
     - name: Configure
       shell: bash
       run: cmake -Bbuild
 
     - name: Build
-      shell: bash
-      run: cmake --build build --config Release --parallel 4
+      run: cmake --build build --config Release
     
     # Failing validation, fix
     #- name: Validate
     #  if: runner.os == 'Windows'
     #  run: bash validate.sh
 
+    - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-lv2
-        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/LV2/Proteus.lv2
+        path: Proteus/Proteus/build/Proteus_artefacts/LV2/*.lv2
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-vst3.so
-        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
+        path: Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
-        name: proteus-linux-x64-clap
+        name: proteus-linux-x64-clap.clap
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-standalone
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
+        if-no-files-found: error
 
-    # couldn't find .vst3
     - uses: actions/upload-artifact@latest
       if: runner.os == 'Windows'
       with:
         name: proteus-windows-x64-shared.lib
         path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus_SharedCode.lib
+        if-no-files-found: error
+
+    - uses: actions/upload-artifact@latest
+      if: runner.os == 'Windows'
+      with:
+        name: proteus-windows-x64-vst3.dll
+        path: D:\a\Proteus\Proteus\build\Proteus_artefacts\Release\Proteus.dll
+        if-no-files-found: error
 
     - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-au
-        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/AU/Proteus.component/Contents/MacOS/Proteus
+        path: Proteus/Proteus/build/Proteus_artefacts/AU/Proteus.component/Contents/MacOS/Proteus
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-vst3
-        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
+        path: Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
-        name: proteus-max-x64-clap
-        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
+        name: proteus-mac-x64-clap.clap
+        path: Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
+        if-no-files-found: error
+
     - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:
         name: proteus-mac-x64-standalone
-        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus.app/Contents/MacOS/Proteus
+        path: Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus.app/Contents/MacOS/Proteus
+        if-no-files-found: error

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,28 +38,28 @@ jobs:
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-lv2
-        path: build/Proteus_artefacts/LV2/*.lv2
+        path: build/Proteus_artefacts/Release/LV2/Proteus.lv2
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-vst3.so
-        path: build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
+        path: build/Proteus_artefacts/Release/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-clap.clap
-        path: build/Proteus_artefacts/CLAP/Proteus.clap
+        path: build/Proteus_artefacts/Release/CLAP/Proteus.clap
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-standalone
-        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
+        path: build/Proteus_artefacts/Release/Standalone/Proteus
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,6 +52,11 @@ jobs:
     - uses: actions/upload-artifact@latest
       if: runner.os == 'Linux'
       with:
+        name: proteus-linux-x64-clap
+        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
+    - uses: actions/upload-artifact@latest
+      if: runner.os == 'Linux'
+      with:
         name: proteus-linux-x64-standalone
         path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/Standalone/Proteus
 
@@ -72,6 +77,11 @@ jobs:
       with:
         name: proteus-mac-x64-vst3
         path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/MacOS/Proteus
+    - uses: actions/upload-artifact@latest
+      if: runner.os == 'macOS'
+      with:
+        name: proteus-max-x64-clap
+        path: /Users/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
     - uses: actions/upload-artifact@latest
       if: runner.os == 'macOS'
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 jobs:
   build_and_test:
     if: contains(toJson(github.event.commits), '***NO_CI***') == false && contains(toJson(github.event.commits), '[ci skip]') == false && contains(toJson(github.event.commits), '[skip ci]') == false
-    name: Test plugin on ${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest] #, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
         version: 1.0
 
     - uses: lukka/get-cmake@latest
-    - run: cmake -Bbuild
+    - run: cmake -Bbuild -GNinja
     - run: cmake --build build --config Release
     
     # Failing validation, fix
@@ -38,21 +38,21 @@ jobs:
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-lv2
-        path: Proteus/Proteus/build/Proteus_artefacts/LV2/*.lv2
+        path: build/Proteus_artefacts/LV2/*.lv2
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-vst3.so
-        path: Proteus/Proteus/build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
+        path: build/Proteus_artefacts/VST3/Proteus.vst3/Contents/x86_64-linux/Proteus.so
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
       with:
         name: proteus-linux-x64-clap.clap
-        path: /home/runner/work/Proteus/Proteus/build/Proteus_artefacts/CLAP/Proteus.clap
+        path: build/Proteus_artefacts/CLAP/Proteus.clap
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,16 +1,5 @@
 name: CI
-
-on:
-  push:
-    branches:
-    - main
-    - develop
-  pull_request:
-    branches:
-    - main
-    - develop
-
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   build_and_test:
@@ -31,7 +20,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
     - name: Get latest CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake
 
     - name: Checkout code
       uses: actions/checkout

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "modules/RTNeural"]
 	path = modules/RTNeural
 	url = https://github.com/jatinchowdhury18/RTNeural.git
-[submodule "clap-juce-extensions"]
-	path = clap-juce-extensions
-	url = https://github.com/free-audio/clap-juce-extensions.git
 [submodule "modules/clap-juce-extensions"]
 	path = modules/clap-juce-extensions
 	url = https://github.com/free-audio/clap-juce-extensions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,9 @@
 [submodule "modules/RTNeural"]
 	path = modules/RTNeural
 	url = https://github.com/jatinchowdhury18/RTNeural.git
+[submodule "clap-juce-extensions"]
+	path = clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions.git
+[submodule "modules/clap-juce-extensions"]
+	path = modules/clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(BUILD_AU3 "" APPLE)
 
 option(BUILD_VST3 "" ON) # VST 2 requires a separate SDK so it's omitted
 
-set(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
+set(LINUX UNIX AND NOT APPLE)
 option(BUILD_LV2 "" LINUX)
 
 option(BUILD_CLAP "" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ta
 option(BUILD_AU "" APPLE)
 option(BUILD_AU3 "" APPLE)
 
-# VST 2 requires a separate SDK so it's omitted
-option(BUILD_VST3 "" ON)
+option(BUILD_VST3 "" ON) # VST 2 requires a separate SDK so it's omitted
 
 set(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
 option(BUILD_LV2 "" LINUX)
 
+option(BUILD_CLAP "" ON)
 option(BUILD_AAX "" ON)
 option(BUILD_STANDALONE "" ON)
 
@@ -45,6 +45,7 @@ endif()
 
 add_subdirectory(modules)
 include_directories(modules)
+add_subdirectory(modules/clap-juce-extensions)
 
 if (UNIX)
     set(LINK_FLAGS "${LINK_FLAGS} -Wl --as-needed")
@@ -103,6 +104,14 @@ juce_add_plugin(Proteus
     AAX_CATEGORY AAX_ePlugInCategory_Harmonic
     MICROPHONE_PERMISSION_ENABLED TRUE
 )
+
+if (BUILD_CLAP)
+    clap_juce_extensions_plugin(TARGET Proteus
+        CLAP_ID "com.guitarml.proteus"
+        CLAP_FEATURES audio-effect filter)
+
+    add_custom_target(BuildCLAP ALL DEPENDS Proteus_CLAP)
+endif()
 
 juce_generate_juce_header(Proteus)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,14 @@ include(CheckIPOSupported)
 
 set(CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment target")
 
 option(BUILD_AU "" APPLE)
 option(BUILD_AU3 "" APPLE)
 
-# VST 2 requires a separate SDK so it's omited
+# VST 2 requires a separate SDK so it's omitted
 option(BUILD_VST3 "" ON)
 
 set(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -45,6 +46,15 @@ endif()
 add_subdirectory(modules)
 include_directories(modules)
 
+if (UNIX)
+    set(LINK_FLAGS "${LINK_FLAGS} -Wl --as-needed")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wpedantic")
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Release")
+        set(LINK_FLAGS "${LINK_FLAGS} -s")
+    endif()
+endif()
+
 set(JUCE_FORMATS "")
 
 if (BUILD_AU)
@@ -60,7 +70,7 @@ if (BUILD_VST3)
 endif()
 
 if (BUILD_LV2)
-    list(APPEND JUCE_FORMATS AU)
+    list(APPEND JUCE_FORMATS LV2)
 endif()
 
 if (BUILD_STANDALONE)
@@ -78,7 +88,7 @@ if (BUILD_AAX)
     endif()
 endif()
 
-message(STATUS "Building " ${JUCE_FORMATS})
+message(STATUS "Building ${JUCE_FORMATS}")
 
 juce_add_plugin(Proteus
     COMPANY_NAME GuitarML
@@ -94,7 +104,6 @@ juce_add_plugin(Proteus
     MICROPHONE_PERMISSION_ENABLED TRUE
 )
 
-# create JUCE header
 juce_generate_juce_header(Proteus)
 
 # add sources
@@ -110,16 +119,14 @@ target_compile_definitions(Proteus
     JUCE_USE_CURL=0
     JUCE_VST3_CAN_REPLACE_VST2=0
     JUCE_MODAL_LOOPS_PERMITTED=1
-    JUCE_PLUGINHOST_LADSPA=BUILD_LV2
+    # We do not set e.g. JUCE_PLUGINHOST_LADSPA=BUILD_LV so as we could re-run cmake without
+    # re-building all from scratch if we want to build LV2
     JUCE_USE_XINERAMA=0 # Use XRandr instead
 )
 
 target_link_libraries(Proteus PUBLIC juce::juce_recommended_lto_flags)
 target_link_libraries(Proteus PUBLIC juce::juce_recommended_config_flags)
-
-if (UNIX)
-    target_link_options(Proteus PRIVATE BEFORE -Wl,--as-needed)
-    target_compile_options(Proteus PRIVATE -Wall -Werror -Wextra -Wpedantic)
-endif()
-
 target_link_libraries(Proteus PUBLIC juce_plugin_modules)
+
+message(STATUS "CXX flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "Linker flags: ${LINK_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,96 @@
 cmake_minimum_required(VERSION 3.15)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment target")
 project(Proteus VERSION 1.2.0)
+include(CheckIPOSupported)
 
 set(CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment target")
+
+option(BUILD_AU "" APPLE)
+option(BUILD_AU3 "" APPLE)
+
+# VST 2 requires a separate SDK so it's omited
+option(BUILD_VST3 "" ON)
+
+set(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
+option(BUILD_LV2 "" LINUX)
+
+option(BUILD_AAX "" ON)
+option(BUILD_STANDALONE "" ON)
+
+option(ENABLE_LTO "" ON)
+
+check_ipo_supported(RESULT result OUTPUT output)
+if(result AND ENABLE_LTO)
+    set_property(GLOBAL PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    message(STATUS "Enabled IPO")
+else()
+    message(WARNING "IPO is disabled or not supported. ${output}")
+endif()
+
+message(STATUS "Compiler:" ${CMAKE_CXX_COMPILER})
+# On Linux, clang is also GNU in CMAKE_CXX_COMPILER_ID
+# You need to pass compiler as CXX=/usr/bin/clang++ explicitly as on Linux
+# the default compiler is /usr/bin/c++, and cmake can't generally follow symlinks
+if (CMAKE_CXX_COMPILER MATCHES "clang")
+    option(CLANG_NEW_PASS_MANAGER "Enable experimental pass manager on modern clang builds" ON)
+
+    if (CLANG_NEW_PASS_MANAGER)
+        message(STATUS "Using clang experimental pass manager")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-new-pass-manager")
+    endif()
+endif()
 
 add_subdirectory(modules)
 include_directories(modules)
 
-#juce_set_aax_sdk_path(C:/SDKs/AAX_SDK/)
+set(JUCE_FORMATS "")
 
-set(JUCE_FORMATS AU VST3 Standalone)
-
-# Build LV2 only on Linux
-if(UNIX AND NOT APPLE)
-    message(STATUS "Building LV2 plugin format")
-    list(APPEND JUCE_FORMATS LV2)
+if (BUILD_AU)
+    list(APPEND JUCE_FORMATS AU)
 endif()
 
-# Build AAX if SDK target exists
-if(TARGET juce_aax_sdk)
-    message(STATUS "Building AAX plugin format")
-    list(APPEND JUCE_FORMATS AAX)
+if (BUILD_AU3)
+    list(APPEND JUCE_FORMATS AUv3)
 endif()
+
+if (BUILD_VST3)
+    list(APPEND JUCE_FORMATS VST3)
+endif()
+
+if (BUILD_LV2)
+    list(APPEND JUCE_FORMATS AU)
+endif()
+
+if (BUILD_STANDALONE)
+    list(APPEND JUCE_FORMATS Standalone)
+endif()
+
+if (BUILD_AAX)
+    option(JUCE_AAX_SDK "Path to JUCE AAX SDK" "")
+    juce_set_aax_sdk_path(JUCE_AAX_SDK)
+
+    if (TARGET juce_aax_sdk)
+        list(APPEND JUCE_FORMATS AAX)
+    else()
+        message(FATAL "JUCE AAX SDK missing")
+    endif()
+endif()
+
+message(STATUS "Building " ${JUCE_FORMATS})
 
 juce_add_plugin(Proteus
     COMPANY_NAME GuitarML
     PLUGIN_MANUFACTURER_CODE GtML
-    PLUGIN_CODE Prt3 
+    PLUGIN_CODE Prt3
     FORMATS ${JUCE_FORMATS}
     ProductName "Proteus"
     LV2URI https://github.com/GuitarML/Proteus
     ICON_BIG resources/logo.png
-
     VST3_CATEGORIES Fx Distortion
     AU_MAIN_TYPE kAudioUnitType_Effect
     AAX_CATEGORY AAX_ePlugInCategory_Harmonic
-
     MICROPHONE_PERMISSION_ENABLED TRUE
 )
 
@@ -55,9 +110,16 @@ target_compile_definitions(Proteus
     JUCE_USE_CURL=0
     JUCE_VST3_CAN_REPLACE_VST2=0
     JUCE_MODAL_LOOPS_PERMITTED=1
+    JUCE_PLUGINHOST_LADSPA=BUILD_LV2
+    JUCE_USE_XINERAMA=0 # Use XRandr instead
 )
 
-target_link_libraries(Proteus PUBLIC
-    juce_plugin_modules
-)
+target_link_libraries(Proteus PUBLIC juce::juce_recommended_lto_flags)
+target_link_libraries(Proteus PUBLIC juce::juce_recommended_config_flags)
 
+if (UNIX)
+    target_link_options(Proteus PRIVATE BEFORE -Wl,--as-needed)
+    target_compile_options(Proteus PRIVATE -Wall -Werror -Wextra -Wpedantic)
+endif()
+
+target_link_libraries(Proteus PUBLIC juce_plugin_modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
 option(BUILD_LV2 "" LINUX)
 
 option(BUILD_CLAP "" ON)
-option(BUILD_AAX "" ON)
+option(BUILD_AAX "" OFF)
 option(BUILD_STANDALONE "" ON)
 
 option(ENABLE_LTO "" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,17 +31,6 @@ else()
 endif()
 
 message(STATUS "Compiler:" ${CMAKE_CXX_COMPILER})
-# On Linux, clang is also GNU in CMAKE_CXX_COMPILER_ID
-# You need to pass compiler as CXX=/usr/bin/clang++ explicitly as on Linux
-# the default compiler is /usr/bin/c++, and cmake can't generally follow symlinks
-if (CMAKE_CXX_COMPILER MATCHES "clang")
-    option(CLANG_NEW_PASS_MANAGER "Enable experimental pass manager on modern clang builds" ON)
-
-    if (CLANG_NEW_PASS_MANAGER)
-        message(STATUS "Using clang experimental pass manager")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-new-pass-manager")
-    endif()
-endif()
 
 add_subdirectory(modules)
 include_directories(modules)
@@ -49,7 +38,8 @@ add_subdirectory(modules/clap-juce-extensions)
 
 if (UNIX)
     set(LINK_FLAGS "${LINK_FLAGS} -Wl --as-needed")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wpedantic")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
         set(LINK_FLAGS "${LINK_FLAGS} -s")

--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ Note: Recommended to follow along with the video tutorials listed above.
 
 ```bash
 # Clone the repository
-$ git clone https://github.com/GuitarML/Proteus.git
+$ git clone https://github.com/GuitarML/Proteus.git --recursive --shallow-submodules
 $ cd Proteus
-
-# initialize and set up submodules
-$ git submodule update --init --recursive
 
 # build with CMake
 $ cmake -Bbuild
 $ cmake --build build --config Release
+
+# If you want to use clang on Linux, pass CC and CXX options explicitly, see
+# CMakeLists.txt:33
+CC=/usr/bin/clang-13 CXX=/usr/bin/clang++-13 cmake -B build <..>
+
 ```
 The binaries will be located in `Proteus/build/Proteus_artefacts/`
 


### PR DESCRIPTION
Hi and thanks for the plugin!
I suggest some changes:
- Using LTO and experimental pass manager if building with Clang (reduces build time)
- Using debug symbol strip for Release binaries on Linux and MacOS (~1000-1200kb size reduction)
- Options to build separate artifacts (VST2, AU, AAX, LV2, and standalone).
- Delivering separate artifacts in Github workflow (ease of use).
- Adding a common formatter (I added .clang-format, but you can use any you want).
- Adding -Wall, -Werror, and -Wpedantic to catch errors